### PR TITLE
feature/table activepage prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ import 'react-smart-data-table/dist/react-smart-data-table.css'
 
 | Name               | Default               | Type                  | Description                                                       |
 | :----------------- | :-------------------- | :-------------------- | :---------------------------------------------------------------- |
+| activePage         | 1                     | {number}              | Initialize or set the table page to the given number              |
 | data               | []                    | {array&#124;string}   | An array of plain objects (can be nested) or a URL                |
 | dataKey            | 'data'                | {string}              | The object key where the async data is available                  |
 | dataKeyResolver    | _null_                | {function}            | Supply a function to extract the data from the async response     |

--- a/example/index.js
+++ b/example/index.js
@@ -6,6 +6,7 @@ import SmartDataTable from 'react-smart-data-table-dev'
 import 'react-smart-data-table-dev.css'
 
 const sematicUI = {
+  button: 'ui button',
   change: 'ui labeled secondary icon button',
   changeIcon: 'exchange icon',
   checkbox: 'ui toggle checkbox',
@@ -115,6 +116,7 @@ class AppDemo extends React.Component {
     this.handleOnChange = this.handleOnChange.bind(this)
     this.handleOnChangeOrder = this.handleOnChangeOrder.bind(this)
     this.handleOnPerPage = this.handleOnPerPage.bind(this)
+    this.handlePage = this.handlePage.bind(this)
     this.onRowClick = this.onRowClick.bind(this)
     this.setNewData = this.setNewData.bind(this)
   }
@@ -225,6 +227,10 @@ class AppDemo extends React.Component {
     this.setState({ [name]: parseInt(value, 10) })
   }
 
+  handlePage({ target: { name, value } }) {
+    this.setState({ [name]: parseInt(value, 10) })
+  }
+
   changeData() {
     const { useApi } = this.state
     this.setState({
@@ -258,6 +264,7 @@ class AppDemo extends React.Component {
 
   render() {
     const {
+      activePage,
       apiUrl,
       apiUrlNew,
       changeOrder,
@@ -301,6 +308,19 @@ class AppDemo extends React.Component {
             <option value="50">50</option>
             <option value="100">100</option>
           </select>
+          {divider}
+          {perPage > 0 && (
+            <>
+              <button
+                className={sematicUI.button}
+                name="activePage"
+                value="4"
+                onClick={this.handlePage}
+              >
+                Call page 4 programmaticly
+              </button>
+            </>
+          )}
           {divider}
           {!useApi && (
             <>
@@ -474,6 +494,7 @@ class AppDemo extends React.Component {
         )}
         {!useApi && (
           <SmartDataTable
+            activePage={activePage}
             name="test-fake-table"
             data={data}
             dataSampling={dataSampling}

--- a/lib/SmartDataTable.tsx
+++ b/lib/SmartDataTable.tsx
@@ -17,6 +17,7 @@ import * as constants from './helpers/constants'
 import './css/basic.css'
 
 interface SmartDataTableProps {
+  activePage: number
   className: string
   data: string | utils.UnknownObject[]
   dataKey: string
@@ -67,7 +68,7 @@ class SmartDataTable extends Component<
     const { headers: colProperties = {} } = props
 
     this.state = {
-      activePage: 1,
+      activePage: props.activePage,
       asyncData: [],
       colProperties,
       columns: [],
@@ -103,8 +104,12 @@ class SmartDataTable extends Component<
   }
 
   componentDidUpdate(prevProps: SmartDataTableProps): void {
-    const { data } = this.props
+    const { data, activePage } = this.props
     const { data: prevData } = prevProps
+
+    if (prevProps.activePage !== activePage) {
+      this.handleOnPageChange(null, { activePage })
+    }
 
     if (
       utils.isString(data) &&
@@ -474,6 +479,7 @@ class SmartDataTable extends Component<
 
 // Defines the type of data expected in each passed prop
 SmartDataTable.propTypes = {
+  activePage: PropTypes.number,
   className: PropTypes.string,
   data: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
   dataKey: PropTypes.string,
@@ -521,6 +527,7 @@ SmartDataTable.propTypes = {
 
 // Defines the default values for not passing a certain prop
 SmartDataTable.defaultProps = {
+  activePage: 1,
   className: '',
   dataKey: constants.DEFAULT_DATA_KEY,
   dataKeyResolver: null,


### PR DESCRIPTION
### Request type

- [x] Feature
- [x] Fix #60
- [ ] Refactor

I need the ability to change the table page programmaticly.
For example reading URL params or using interactive elements everywhere in an application to change the active table page. 
Now it is also possible to write an independent `<Pagination />` component without using the build-in one, so you have full control about the markup.


### Change description

There is a new prop called `activePage`, the default value is `1`.
Also I changed the example a bit.

### Check lists

- [x] Tests passed
- [x] Coding style respected
