### PR TITLE
feat: performance optimisations

### DIFF
--- a/lib/SmartDataTable.perf.test.tsx
+++ b/lib/SmartDataTable.perf.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import SmartDataTable from './SmartDataTable'
+import * as utils from './helpers/functions'
+
+// Generate 10k rows with 10 columns each
+function generateRows(count: number) {
+  const rows = []
+
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      id: i,
+      first_name: `First${i}`,
+      last_name: `Last${i}`,
+      email: `user${i}@example.com`,
+      phone: `555-${String(i).padStart(4, '0')}`,
+      city: `City${i % 100}`,
+      country: `Country${i % 50}`,
+      company: `Company${i % 200}`,
+      department: `Dept${i % 20}`,
+      salary: 30000 + (i % 70000),
+    })
+  }
+
+  return rows
+}
+
+const ROW_COUNT = 10_000
+const PER_PAGE = 50
+const testData = generateRows(ROW_COUNT)
+
+describe('SmartDataTable Performance', () => {
+  let parseDataForRowsSpy: ReturnType<typeof jest.spyOn>
+
+  beforeEach(() => {
+    parseDataForRowsSpy = jest.spyOn(utils, 'parseDataForRows')
+  })
+
+  afterEach(() => {
+    parseDataForRowsSpy.mockRestore()
+  })
+
+  it('renders 10k rows without crashing', () => {
+    const { container } = render(
+      <SmartDataTable data={testData} name="perf-test" perPage={PER_PAGE} />,
+    )
+
+    expect(container.querySelector('table')).toBeTruthy()
+    expect(parseDataForRowsSpy).toHaveBeenCalled()
+  })
+
+  it('measures initial render time', () => {
+    const start = performance.now()
+
+    render(
+      <SmartDataTable data={testData} name="perf-test" perPage={PER_PAGE} />,
+    )
+
+    const elapsed = performance.now() - start
+
+    // Log for baseline comparison — this is not a pass/fail assertion
+    console.log(
+      `[PERF] Initial render (${ROW_COUNT} rows): ${elapsed.toFixed(1)}ms`,
+    )
+
+    // Sanity check: should complete within 10 seconds even on slow CI
+    expect(elapsed).toBeLessThan(10_000)
+  })
+
+  it('tracks parseDataForRows calls on page change', () => {
+    render(
+      <SmartDataTable
+        data={testData}
+        name="perf-test"
+        perPage={PER_PAGE}
+        sortable
+      />,
+    )
+
+    const initialCallCount = parseDataForRowsSpy.mock.calls.length
+
+    // Click "next page" button
+    const nextButton = screen
+      .getAllByTestId('paginator-item')
+      .find((el) => el.textContent === '>')
+
+    expect(nextButton).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(nextButton!)
+    })
+
+    const callsAfterPageChange = parseDataForRowsSpy.mock.calls.length
+
+    // BEFORE optimization: parseDataForRows IS called again on page change
+    // AFTER optimization: parseDataForRows should NOT be called again
+    // We record both values so we can compare before/after the refactor
+    const extraCalls = callsAfterPageChange - initialCallCount
+
+    console.log(
+      `[PERF] parseDataForRows calls on page change: ${extraCalls} ` +
+        `(initial: ${initialCallCount}, after: ${callsAfterPageChange})`,
+    )
+
+    // Memoization: page change must NOT trigger re-flatten
+    expect(extraCalls).toBe(0)
+  })
+
+  it('tracks parseDataForRows calls on sort change', () => {
+    render(
+      <SmartDataTable
+        data={testData}
+        name="perf-test"
+        perPage={PER_PAGE}
+        sortable
+      />,
+    )
+
+    const initialCallCount = parseDataForRowsSpy.mock.calls.length
+
+    // Click a column header sorting icon
+    const sortIcon = document.querySelector('.rsdt-sortable-icon')
+
+    expect(sortIcon).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(sortIcon!)
+    })
+
+    const callsAfterSort = parseDataForRowsSpy.mock.calls.length
+    const extraCalls = callsAfterSort - initialCallCount
+
+    console.log(
+      `[PERF] parseDataForRows calls on sort: ${extraCalls} ` +
+        `(initial: ${initialCallCount}, after: ${callsAfterSort})`,
+    )
+
+    // Memoization: sort change must NOT trigger re-flatten
+    expect(extraCalls).toBe(0)
+  })
+
+  it('tracks parseDataForRows calls on filter change', () => {
+    const { rerender } = render(
+      <SmartDataTable
+        data={testData}
+        name="perf-test"
+        perPage={PER_PAGE}
+        sortable
+        filterValue=""
+      />,
+    )
+
+    const initialCallCount = parseDataForRowsSpy.mock.calls.length
+
+    rerender(
+      <SmartDataTable
+        data={testData}
+        name="perf-test"
+        perPage={PER_PAGE}
+        sortable
+        filterValue="First42"
+      />,
+    )
+
+    const callsAfterFilter = parseDataForRowsSpy.mock.calls.length
+    const extraCalls = callsAfterFilter - initialCallCount
+
+    console.log(
+      `[PERF] parseDataForRows calls on filter: ${extraCalls} ` +
+        `(initial: ${initialCallCount}, after: ${callsAfterFilter})`,
+    )
+
+    // Memoization: filter change must NOT trigger re-flatten
+    expect(extraCalls).toBe(0)
+  })
+})

--- a/lib/SmartDataTable.tsx
+++ b/lib/SmartDataTable.tsx
@@ -280,7 +280,7 @@ function SmartDataTable<T = utils.UnknownObject>({
     return loader
   }
 
-  if (utils.isEmpty(filteredRows) && utils.isEmpty(resolvedData)) {
+  if (utils.isEmpty(filteredRows)) {
     return emptyTable
   }
 

--- a/lib/SmartDataTable.tsx
+++ b/lib/SmartDataTable.tsx
@@ -1,275 +1,192 @@
-import { Component } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { MouseEvent, ReactNode } from 'react'
 import cx from 'clsx'
-import CellValue from './components/CellValue'
+import DataRow from './components/DataRow'
 import ErrorBoundary from './components/ErrorBoundary'
 import Paginator from './components/Paginator'
 import Table from './components/Table'
 import Toggles from './components/Toggles'
-import withPagination from './components/helpers/with-pagination'
 import { SmartDataTableContext } from './helpers/context'
-import type { SmartDataTableProps, SmartDataTableState } from './types'
+import TableAction from './helpers/table-action.enum'
+import { useTableReducer } from './hooks/useTableReducer'
+import { useAsyncData } from './hooks/useAsyncData'
+import { useColumns } from './hooks/useColumns'
+import { useRows } from './hooks/useRows'
+import type { SmartDataTableProps } from './types'
 import * as constants from './helpers/constants'
 import * as utils from './helpers/functions'
-import defaultState from './helpers/default-state'
 import './css/basic.css'
 
-class SmartDataTable<T = utils.UnknownObject> extends Component<
-  SmartDataTableProps<T>,
-  SmartDataTableState<T>
-> {
-  static defaultProps: SmartDataTableProps<utils.UnknownObject> = {
-    className: '',
-    data: undefined,
-    dataKey: constants.DEFAULT_DATA_KEY,
-    dataKeyResolver: null,
-    dataRequestOptions: {},
-    dataSampling: 0,
-    dynamic: false,
-    emptyTable: null,
-    filterValue: '',
-    headers: {},
-    hideUnordered: false,
-    loader: null,
-    name: 'reactsmartdatatable',
-    onRowClick: () => null,
-    orderedHeaders: [],
-    paginator: Paginator,
-    parseBool: false,
-    parseImg: false,
-    perPage: 0,
-    sortable: false,
-    withFooter: false,
-    withHeader: true,
-    withLinks: false,
-    withToggles: false,
-  }
+function SmartDataTable<T = utils.UnknownObject>({
+  className = '',
+  data,
+  dataKey = constants.DEFAULT_DATA_KEY,
+  dataKeyResolver = null,
+  dataRequestOptions = {},
+  dataSampling = 0,
+  dynamic = false,
+  emptyTable = null,
+  filterValue = '',
+  headers = {} as utils.Headers<T>,
+  hideUnordered = false,
+  loader = null,
+  name = 'reactsmartdatatable',
+  onRowClick = () => null,
+  orderedHeaders = [],
+  paginator: PaginatorComponent = Paginator,
+  parseBool = false,
+  parseImg = false,
+  perPage = 0,
+  sortable = false,
+  withFooter = false,
+  withHeader = true,
+  withLinks = false,
+  withToggles = false,
+}: Partial<SmartDataTableProps<T>>): ReactNode {
+  const [state, dispatch] = useTableReducer<T>(headers)
+  const {
+    activePage,
+    asyncData,
+    colProperties,
+    columns: stateColumns,
+    isLoading,
+    sorting,
+  } = state
 
-  constructor(props: SmartDataTableProps<T>) {
-    super(props)
+  // Sync filter value → reset page
+  const prevFilterRef = useRef(filterValue)
 
-    const { headers: colProperties = {} } = props
+  useEffect(() => {
+    if (filterValue !== prevFilterRef.current) {
+      prevFilterRef.current = filterValue
+      dispatch({ type: TableAction.ResetPageForFilter, filterValue })
+    }
+  }, [filterValue, dispatch])
 
-    this.state = { ...defaultState, colProperties }
-  }
+  // Fetch async data
+  useAsyncData<T>({
+    data: data as string | T[],
+    dataKey,
+    dataKeyResolver,
+    dataRequestOptions,
+    headers,
+    orderedHeaders,
+    hideUnordered,
+    dataSampling,
+    dispatch,
+  })
 
-  static getDerivedStateFromProps(
-    props: SmartDataTableProps,
-    state: SmartDataTableState,
-  ): SmartDataTableState | null {
-    const { filterValue } = props
-    const { prevFilterValue } = state
+  // Layer 1: Resolve data source
+  const resolvedData = useMemo(
+    () => (utils.isString(data) ? asyncData : (data as T[])),
+    [data, asyncData],
+  )
 
-    if (filterValue !== prevFilterValue) {
-      return {
-        ...state,
-        activePage: 1,
-        prevFilterValue: filterValue,
+  // Memoized columns
+  const columns = useColumns<T>({
+    resolvedData,
+    stateColumns,
+    headers,
+    orderedHeaders,
+    hideUnordered,
+    dataSampling,
+    dynamic,
+  })
+
+  // Memoized row pipeline
+  const { filteredRows, visibleRows } = useRows<T>({
+    resolvedData,
+    sorting,
+    colProperties,
+    filterValue,
+    activePage,
+    perPage,
+  })
+
+  // Stable callbacks
+  const handleOnPageChange = useCallback(
+    (
+      _e: MouseEvent<HTMLElement>,
+      { activePage: page }: { activePage: number },
+    ) => {
+      dispatch({ type: TableAction.SetActivePage, activePage: page })
+    },
+    [dispatch],
+  )
+
+  const handleSortChange = useCallback(
+    (column: utils.Column<T>) => {
+      dispatch({ type: TableAction.SetSorting, column })
+    },
+    [dispatch],
+  )
+
+  const handleColumnToggle = useCallback(
+    (key: string) => {
+      dispatch({ type: TableAction.ToggleColumn, key })
+    },
+    [dispatch],
+  )
+
+  const handleColumnToggleAll = useCallback(
+    (toggleColumns: utils.Column<T>[]) => (isChecked: boolean) => {
+      dispatch({
+        type: TableAction.ToggleAllColumns,
+        columns: toggleColumns,
+        isChecked,
+      })
+    },
+    [dispatch],
+  )
+
+  const handleRowClick = useCallback(
+    (
+      event: MouseEvent<HTMLElement>,
+      rowData: T,
+      rowIndex: number,
+      tableData: T[],
+    ) => {
+      if (typeof onRowClick === 'function') {
+        onRowClick(event, { rowData, rowIndex, tableData })
       }
-    }
+    },
+    [onRowClick],
+  )
 
-    return null
-  }
+  // Pagination: totalPages computed inline (fixes stale HOC bug)
+  const totalPages = useMemo(
+    () => (perPage > 0 ? Math.ceil(filteredRows.length / perPage) : 0),
+    [filteredRows.length, perPage],
+  )
 
-  componentDidMount() {
-    void this.fetchData()
-  }
+  // Memoized toggle-all for current columns
+  const toggleAll = useMemo(
+    () => handleColumnToggleAll(columns),
+    [handleColumnToggleAll, columns],
+  )
 
-  componentDidUpdate(prevProps: SmartDataTableProps<T>) {
-    const { data } = this.props
-    const { data: prevData } = prevProps
+  // Memoized context value
+  const contextValue = useMemo(() => state, [state])
 
-    if (
-      utils.isString(data) &&
-      (typeof data !== typeof prevData || data !== prevData)
-    ) {
-      void this.fetchData()
-    }
-  }
-
-  handleRowClick = (
-    event: MouseEvent<HTMLElement>,
-    rowData: T,
-    rowIndex: number,
-    tableData: T[],
-  ) => {
-    const { onRowClick } = this.props
-
-    if (typeof onRowClick === 'function') {
-      onRowClick(event, { rowData, rowIndex, tableData })
-    }
-  }
-
-  handleColumnToggle = (key: string) => {
-    const { colProperties } = this.state
-    const newColProperties = { ...colProperties }
-
-    if (!newColProperties[key]) {
-      newColProperties[key] = {
-        ...constants.defaultHeader,
-        key,
-      }
-    }
-
-    newColProperties[key].invisible = !newColProperties[key].invisible
-
-    this.setState({ colProperties: newColProperties })
-  }
-
-  handleColumnToggleAll =
-    (columns: utils.Column<T>[]) => (isChecked: boolean) => {
-      const { colProperties } = this.state
-      const newColProperties = { ...colProperties }
-
-      for (const { key } of columns) {
-        if (!newColProperties[key]) {
-          newColProperties[key] = {
-            ...constants.defaultHeader,
-            key,
-          }
-        }
-
-        newColProperties[key].invisible = isChecked
-      }
-
-      this.setState({ colProperties: newColProperties })
-    }
-
-  handleOnPageChange = (
-    event: MouseEvent<HTMLElement>,
-    { activePage }: { activePage: number },
-  ) => {
-    this.setState({ activePage })
-  }
-
-  handleSortChange(column: utils.Column<T>) {
-    const { sorting } = this.state
-    const { key } = column
-    let dir: string
-
-    if (key !== sorting.key) {
-      sorting.dir = ''
-    }
-
-    if (sorting.dir) {
-      if (sorting.dir === constants.ORDER_ASC) {
-        dir = constants.ORDER_DESC
-      } else {
-        dir = ''
-      }
-    } else {
-      dir = constants.ORDER_ASC
-    }
-
-    this.setState({
-      sorting: {
-        key,
-        dir,
-      },
-    })
-  }
-
-  getColumns(force = false): utils.Column<T>[] {
-    const { asyncData, columns } = this.state
-    const {
-      data: propsData,
-      dataSampling,
-      headers,
-      hideUnordered,
-      orderedHeaders,
-    } = this.props
-
-    if (!force && !utils.isEmpty(columns)) {
-      return columns
-    }
-
-    let data = propsData as T[]
-
-    if (utils.isString(data)) {
-      data = asyncData
-    }
-
-    return utils.parseDataForColumns<T>(
-      data,
-      headers,
-      orderedHeaders,
-      hideUnordered,
-      dataSampling,
-    )
-  }
-
-  getRows(): T[] {
-    const { asyncData, colProperties, sorting } = this.state
-    const { data: propsData, filterValue } = this.props
-
-    let data = propsData as T[]
-
-    if (utils.isString(data)) {
-      data = asyncData
-    }
-
-    return utils.sortData(
-      filterValue,
-      colProperties,
-      sorting,
-      utils.parseDataForRows(data),
-    )
-  }
-
-  async fetchData(): Promise<void> {
-    const {
-      data,
-      dataKey,
-      dataKeyResolver,
-      dataRequestOptions: options,
-    } = this.props
-
-    if (utils.isString(data)) {
-      this.setState({ isLoading: true })
-
-      try {
-        const asyncData = await utils.fetchData(data, {
-          dataKey,
-          dataKeyResolver,
-          options,
-        })
-
-        this.setState({
-          asyncData,
-          isLoading: false,
-          columns: this.getColumns(true),
-        })
-      } catch (err) {
-        this.setState({
-          isLoading: false,
-        })
-
-        throw new Error(String(err), { cause: err })
-      }
-    }
-  }
-
-  renderSorting(column: utils.Column<T>): ReactNode {
-    const {
-      sorting: { key, dir },
-    } = this.state
+  // Render helpers
+  const renderSorting = (column: utils.Column<T>): ReactNode => {
+    const { key, dir } = sorting
     let sortingIcon = 'rsdt-sortable-icon'
 
     if (key === column.key) {
       if (dir) {
-        if (dir === constants.ORDER_ASC) {
-          sortingIcon = 'rsdt-sortable-asc'
-        } else {
-          sortingIcon = 'rsdt-sortable-desc'
-        }
+        sortingIcon =
+          dir === constants.ORDER_ASC
+            ? 'rsdt-sortable-asc'
+            : 'rsdt-sortable-desc'
       }
     }
 
     return (
       <i
         className={cx('rsdt', sortingIcon)}
-        onClick={() => this.handleSortChange(column)}
-        onKeyDown={() => this.handleSortChange(column)}
+        onClick={() => handleSortChange(column)}
+        onKeyDown={() => handleSortChange(column)}
         role="button"
         tabIndex={0}
         aria-label="sorting column"
@@ -277,10 +194,8 @@ class SmartDataTable<T = utils.UnknownObject> extends Component<
     )
   }
 
-  renderHeader(columns: utils.Column<T>[]): ReactNode {
-    const { colProperties } = this.state
-    const { sortable } = this.props
-    const headers = columns.map((column) => {
+  const renderHeader = (): ReactNode => {
+    const headerCells = columns.map((column) => {
       const thisColProps = colProperties[column.key]
       const showCol = !thisColProps || !thisColProps.invisible
 
@@ -292,77 +207,38 @@ class SmartDataTable<T = utils.UnknownObject> extends Component<
         <Table.HeaderCell data-column-name={column.key} key={column.key}>
           <span>{column.text}</span>
           <span className="rsdt rsdt-sortable">
-            {sortable && column.sortable ? this.renderSorting(column) : null}
+            {sortable && column.sortable ? renderSorting(column) : null}
           </span>
         </Table.HeaderCell>
       )
     })
 
-    return <Table.Row>{headers}</Table.Row>
+    return <Table.Row>{headerCells}</Table.Row>
   }
 
-  renderRow(columns: utils.Column<T>[], row: T, i: number): ReactNode {
-    const { colProperties } = this.state
-    const { withLinks, filterValue, parseBool, parseImg } = this.props
-
-    return columns.map((column, j) => {
-      const thisColProps = { ...colProperties[column.key] }
-      const showCol = !thisColProps.invisible
-      const transformFn = thisColProps.transform
-
-      if (!showCol) {
-        return null
-      }
-
-      return (
-        <Table.Cell
-          data-column-name={column.key}
-          key={`row-${i}-${column.key}`}
-        >
-          {utils.isFunction(transformFn) ? (
-            transformFn(row[column.key], i, row)
-          ) : (
-            <ErrorBoundary>
-              <CellValue
-                withLinks={withLinks}
-                filterValue={filterValue}
-                parseBool={parseBool}
-                parseImg={parseImg}
-                filterable={thisColProps.filterable}
-                isImg={thisColProps.isImg}
-              >
-                {row[column.key]}
-              </CellValue>
-            </ErrorBoundary>
-          )}
-        </Table.Cell>
-      )
-    })
-  }
-
-  renderBody(columns: utils.Column<T>[], rows: T[]): ReactNode {
-    const { perPage } = this.props
-    const { activePage } = this.state
-    const visibleRows = utils.sliceRowsPerPage(rows, activePage, perPage)
+  const renderBody = (): ReactNode => {
     const tableRows = visibleRows.map((row, idx) => (
-      <Table.Row
-        // eslint-disable-next-line @eslint-react/no-array-index-key -- rows have no guaranteed unique ID in generic data tables
-        key={`row-${idx}`}
-        onClick={(event: MouseEvent<HTMLTableRowElement>) =>
-          this.handleRowClick(event, row, idx, rows)
-        }
-      >
-        {this.renderRow(columns, row, idx)}
-      </Table.Row>
+      // eslint-disable-next-line @eslint-react/no-array-index-key -- rows have no guaranteed unique ID in generic data tables
+      <ErrorBoundary key={`row-${idx}`}>
+        <DataRow<T>
+          row={row}
+          rowIndex={idx}
+          columns={columns}
+          colProperties={colProperties}
+          withLinks={withLinks}
+          filterValue={filterValue}
+          parseBool={parseBool}
+          parseImg={parseImg}
+          onRowClick={handleRowClick}
+          tableData={filteredRows}
+        />
+      </ErrorBoundary>
     ))
 
     return <Table.Body>{tableRows}</Table.Body>
   }
 
-  renderToggles(columns: utils.Column<T>[]): ReactNode {
-    const { colProperties } = this.state
-    const { withToggles } = this.props
-
+  const renderToggles = (): ReactNode => {
     const togglesProps = typeof withToggles === 'object' ? withToggles : {}
 
     if (!withToggles) {
@@ -374,75 +250,51 @@ class SmartDataTable<T = utils.UnknownObject> extends Component<
         <Toggles<T>
           columns={columns}
           colProperties={colProperties}
-          handleColumnToggle={this.handleColumnToggle}
-          handleColumnToggleAll={this.handleColumnToggleAll(columns)}
+          handleColumnToggle={handleColumnToggle}
+          handleColumnToggleAll={toggleAll}
           selectAll={togglesProps?.selectAll}
         />
       </ErrorBoundary>
     )
   }
 
-  renderPagination(rows: T[]): ReactNode {
-    const { perPage, paginator: PaginatorComponent } = this.props
-    const { activePage } = this.state
-    const Paginate = withPagination<T>(PaginatorComponent)
-
-    if (!perPage || perPage <= 0) {
+  const renderPagination = (): ReactNode => {
+    if (!perPage || perPage <= 0 || !totalPages) {
       return null
     }
 
     return (
       <ErrorBoundary>
-        <Paginate
-          rows={rows}
-          perPage={perPage}
+        <PaginatorComponent
+          totalPages={totalPages}
           activePage={activePage}
-          onPageChange={this.handleOnPageChange}
+          onPageChange={handleOnPageChange}
         />
       </ErrorBoundary>
     )
   }
 
-  render() {
-    const {
-      className,
-      dynamic,
-      emptyTable,
-      loader,
-      name,
-      withFooter,
-      withHeader,
-    } = this.props
-    const { isLoading } = this.state
-    const columns = this.getColumns(dynamic)
-    const rows = this.getRows()
-
-    if (isLoading) {
-      return loader
-    }
-
-    if (utils.isEmpty(rows)) {
-      return emptyTable
-    }
-
-    return (
-      <SmartDataTableContext value={this.state}>
-        <section className="rsdt rsdt-container">
-          {this.renderToggles(columns)}
-          <Table data-table-name={name} className={className}>
-            {withHeader && (
-              <Table.Header>{this.renderHeader(columns)}</Table.Header>
-            )}
-            {this.renderBody(columns, rows)}
-            {withFooter && (
-              <Table.Footer>{this.renderHeader(columns)}</Table.Footer>
-            )}
-          </Table>
-          {this.renderPagination(rows)}
-        </section>
-      </SmartDataTableContext>
-    )
+  if (isLoading) {
+    return loader
   }
+
+  if (utils.isEmpty(filteredRows) && utils.isEmpty(resolvedData)) {
+    return emptyTable
+  }
+
+  return (
+    <SmartDataTableContext value={contextValue}>
+      <section className="rsdt rsdt-container">
+        {renderToggles()}
+        <Table data-table-name={name} className={className}>
+          {withHeader && <Table.Header>{renderHeader()}</Table.Header>}
+          {renderBody()}
+          {withFooter && <Table.Footer>{renderHeader()}</Table.Footer>}
+        </Table>
+        {renderPagination()}
+      </section>
+    </SmartDataTableContext>
+  )
 }
 
 export default SmartDataTable

--- a/lib/SmartDataTable.tsx
+++ b/lib/SmartDataTable.tsx
@@ -17,22 +17,27 @@ import * as constants from './helpers/constants'
 import * as utils from './helpers/functions'
 import './css/basic.css'
 
+const EMPTY_HEADERS = {} as utils.Headers<never>
+const EMPTY_ORDERED_HEADERS: string[] = []
+const EMPTY_REQUEST_OPTIONS: RequestInit = {}
+const NOOP_ROW_CLICK = () => null
+
 function SmartDataTable<T = utils.UnknownObject>({
   className = '',
   data,
   dataKey = constants.DEFAULT_DATA_KEY,
   dataKeyResolver = null,
-  dataRequestOptions = {},
+  dataRequestOptions = EMPTY_REQUEST_OPTIONS,
   dataSampling = 0,
   dynamic = false,
   emptyTable = null,
   filterValue = '',
-  headers = {} as utils.Headers<T>,
+  headers = EMPTY_HEADERS as utils.Headers<T>,
   hideUnordered = false,
   loader = null,
   name = 'reactsmartdatatable',
-  onRowClick = () => null,
-  orderedHeaders = [],
+  onRowClick = NOOP_ROW_CLICK,
+  orderedHeaders = EMPTY_ORDERED_HEADERS,
   paginator: PaginatorComponent = Paginator,
   parseBool = false,
   parseImg = false,
@@ -165,9 +170,6 @@ function SmartDataTable<T = utils.UnknownObject>({
     [handleColumnToggleAll, columns],
   )
 
-  // Memoized context value
-  const contextValue = useMemo(() => state, [state])
-
   // Render helpers
   const renderSorting = (column: utils.Column<T>): ReactNode => {
     const { key, dir } = sorting
@@ -283,7 +285,7 @@ function SmartDataTable<T = utils.UnknownObject>({
   }
 
   return (
-    <SmartDataTableContext value={contextValue}>
+    <SmartDataTableContext value={state}>
       <section className="rsdt rsdt-container">
         {renderToggles()}
         <Table data-table-name={name} className={className}>

--- a/lib/components/DataRow.tsx
+++ b/lib/components/DataRow.tsx
@@ -1,0 +1,90 @@
+import { memo, useCallback } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
+import CellValue from './CellValue'
+import Table from './Table'
+import type {
+  Column,
+  Headers,
+  ParseBool,
+  ParseImg,
+  UnknownObject,
+} from '../helpers/functions'
+import * as utils from '../helpers/functions'
+
+interface DataRowProps<T> {
+  row: T
+  rowIndex: number
+  columns: Column<T>[]
+  colProperties: Headers<T>
+  withLinks: boolean
+  filterValue: string
+  parseBool: boolean | ParseBool
+  parseImg: boolean | ParseImg
+  onRowClick: (
+    event: MouseEvent<HTMLElement>,
+    rowData: T,
+    rowIndex: number,
+    tableData: T[],
+  ) => void
+  tableData: T[]
+}
+
+function DataRowInner<T = UnknownObject>({
+  row,
+  rowIndex,
+  columns,
+  colProperties,
+  withLinks,
+  filterValue,
+  parseBool,
+  parseImg,
+  onRowClick,
+  tableData,
+}: DataRowProps<T>): ReactNode {
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLTableRowElement>) => {
+      onRowClick(event, row, rowIndex, tableData)
+    },
+    [onRowClick, row, rowIndex, tableData],
+  )
+
+  return (
+    <Table.Row onClick={handleClick}>
+      {columns.map((column) => {
+        const thisColProps = { ...colProperties[column.key] }
+        const showCol = !thisColProps.invisible
+        const transformFn = thisColProps.transform
+
+        if (!showCol) {
+          return null
+        }
+
+        return (
+          <Table.Cell
+            data-column-name={column.key}
+            key={`row-${rowIndex}-${column.key}`}
+          >
+            {utils.isFunction(transformFn) ? (
+              transformFn(row[column.key], rowIndex, row)
+            ) : (
+              <CellValue
+                withLinks={withLinks}
+                filterValue={filterValue}
+                parseBool={parseBool}
+                parseImg={parseImg}
+                filterable={thisColProps.filterable}
+                isImg={thisColProps.isImg}
+              >
+                {row[column.key]}
+              </CellValue>
+            )}
+          </Table.Cell>
+        )
+      })}
+    </Table.Row>
+  )
+}
+
+const DataRow = memo(DataRowInner) as typeof DataRowInner
+
+export default DataRow

--- a/lib/components/DataRow.tsx
+++ b/lib/components/DataRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react'
+import { useCallback } from 'react'
 import type { MouseEvent, ReactNode } from 'react'
 import CellValue from './CellValue'
 import Table from './Table'
@@ -10,6 +10,7 @@ import type {
   UnknownObject,
 } from '../helpers/functions'
 import * as utils from '../helpers/functions'
+import { typedMemo } from '../helpers/typed-memo'
 
 interface DataRowProps<T> {
   row: T
@@ -85,6 +86,6 @@ function DataRowInner<T = UnknownObject>({
   )
 }
 
-const DataRow = memo(DataRowInner) as typeof DataRowInner
+const DataRow = typedMemo(DataRowInner)
 
 export default DataRow

--- a/lib/components/DataRow.tsx
+++ b/lib/components/DataRow.tsx
@@ -52,9 +52,9 @@ function DataRowInner<T = UnknownObject>({
   return (
     <Table.Row onClick={handleClick}>
       {columns.map((column) => {
-        const thisColProps = { ...colProperties[column.key] }
-        const showCol = !thisColProps.invisible
-        const transformFn = thisColProps.transform
+        const thisColProps = colProperties[column.key]
+        const showCol = !thisColProps?.invisible
+        const transformFn = thisColProps?.transform
 
         if (!showCol) {
           return null
@@ -73,8 +73,8 @@ function DataRowInner<T = UnknownObject>({
                 filterValue={filterValue}
                 parseBool={parseBool}
                 parseImg={parseImg}
-                filterable={thisColProps.filterable}
-                isImg={thisColProps.isImg}
+                filterable={thisColProps?.filterable}
+                isImg={thisColProps?.isImg}
               >
                 {row[column.key]}
               </CellValue>

--- a/lib/components/Table.tsx
+++ b/lib/components/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 import type { FC, PropsWithChildren } from 'react'
 
 interface TableComponent extends FC<
@@ -16,30 +16,29 @@ const Table: TableComponent = ({ children, ...props }) => (
   <table {...props}>{children}</table>
 )
 
-const TableBody: TableComponent['Body'] = ({ children, ...props }) => (
+const TableBody: TableComponent['Body'] = memo(({ children, ...props }) => (
   <tbody {...props}>{children}</tbody>
-)
+))
 
-const TableCell: TableComponent['Cell'] = ({ children, ...props }) => (
+const TableCell: TableComponent['Cell'] = memo(({ children, ...props }) => (
   <td {...props}>{children}</td>
-)
+))
 
-const TableFooter: TableComponent['Footer'] = ({ children, ...props }) => (
+const TableFooter: TableComponent['Footer'] = memo(({ children, ...props }) => (
   <tfoot {...props}>{children}</tfoot>
-)
+))
 
-const TableHeader: TableComponent['Header'] = ({ children, ...props }) => (
+const TableHeader: TableComponent['Header'] = memo(({ children, ...props }) => (
   <thead {...props}>{children}</thead>
+))
+
+const TableHeaderCell: TableComponent['HeaderCell'] = memo(
+  ({ children, ...props }) => <th {...props}>{children}</th>,
 )
 
-const TableHeaderCell: TableComponent['HeaderCell'] = ({
-  children,
-  ...props
-}) => <th {...props}>{children}</th>
-
-const TableRow: TableComponent['Row'] = ({ children, ...props }) => (
+const TableRow: TableComponent['Row'] = memo(({ children, ...props }) => (
   <tr {...props}>{children}</tr>
-)
+))
 
 Table.Body = TableBody
 Table.Cell = TableCell

--- a/lib/components/helpers/with-pagination.ts
+++ b/lib/components/helpers/with-pagination.ts
@@ -1,0 +1,7 @@
+import type { PageChangeFn } from '../PaginatorItem'
+
+export interface WrappedComponentProps {
+  activePage: number
+  onPageChange: PageChangeFn
+  totalPages: number
+}

--- a/lib/components/helpers/with-pagination.tsx
+++ b/lib/components/helpers/with-pagination.tsx
@@ -1,64 +1,7 @@
-import { Component, ComponentType } from 'react'
-import { PageChangeFn } from '../PaginatorItem'
-import * as utils from '../../helpers/functions'
+import type { PageChangeFn } from '../PaginatorItem'
 
 export interface WrappedComponentProps {
   activePage: number
   onPageChange: PageChangeFn
   totalPages: number
 }
-
-interface PaginationWrapperProps<T = utils.UnknownObject> {
-  rows: T[]
-  perPage: number
-  activePage: number
-  onPageChange: PageChangeFn
-}
-
-interface PaginationWrapperState {
-  totalPages: number
-}
-
-const withPagination = <T,>(
-  WrappedComponent: ComponentType<WrappedComponentProps>,
-): ComponentType<PaginationWrapperProps<T>> => {
-  class PaginationWrapper extends Component<
-    PaginationWrapperProps<T>,
-    PaginationWrapperState
-  > {
-    static defaultProps: PaginationWrapperProps<T> = {
-      rows: [],
-      perPage: 10,
-      activePage: 1,
-      onPageChange: () => null,
-    }
-
-    constructor(props: PaginationWrapperProps<T>) {
-      super(props)
-
-      const { rows, perPage } = props
-      this.state = { totalPages: Math.ceil(rows.length / +perPage) }
-    }
-
-    render() {
-      const { activePage, onPageChange } = this.props
-      const { totalPages } = this.state
-
-      if (!totalPages) {
-        return null
-      }
-
-      return (
-        <WrappedComponent
-          totalPages={totalPages}
-          activePage={+activePage}
-          onPageChange={onPageChange}
-        />
-      )
-    }
-  }
-
-  return PaginationWrapper
-}
-
-export default withPagination

--- a/lib/components/helpers/with-pagination.tsx
+++ b/lib/components/helpers/with-pagination.tsx
@@ -1,7 +1,0 @@
-import type { PageChangeFn } from '../PaginatorItem'
-
-export interface WrappedComponentProps {
-  activePage: number
-  onPageChange: PageChangeFn
-  totalPages: number
-}

--- a/lib/helpers/functions.table.test.ts
+++ b/lib/helpers/functions.table.test.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import {
+  capitalize,
   capitalizeAll,
   columnObject,
   fetchData,
@@ -148,6 +149,43 @@ test('getNestedObject(), should return a nested value or null', () => {
   expect(twoLevelValue).toBe(nestedObject.two.twoOne)
   expect(threeLevelValue).toBe(nestedObject.two.twoTwo.twoTwoOne)
   expect(fourLevelValue).toBeUndefined()
+})
+
+describe('capitalize(), should capitalize the first lowercase letter', () => {
+  it('capitalizes a simple word', () => {
+    expect(capitalize('hello')).toBe('Hello')
+  })
+
+  it('capitalizes when leading non-lowercase chars exist', () => {
+    expect(capitalize('--hello')).toBe('--Hello')
+  })
+
+  it('handles all uppercase input', () => {
+    expect(capitalize('HELLO')).toBe('HELLO')
+  })
+
+  it('handles empty string', () => {
+    expect(capitalize('')).toBe('')
+  })
+
+  it('handles non-string input', () => {
+    expect(capitalize(123 as unknown as string)).toBe('')
+  })
+
+  it('handles strings with no lowercase letters', () => {
+    expect(capitalize('123!@#')).toBe('123!@#')
+  })
+
+  it('does not suffer from ReDoS on repeated backticks', () => {
+    const malicious = '`'.repeat(10_000)
+    const start = performance.now()
+
+    capitalize(malicious)
+
+    const elapsed = performance.now() - start
+
+    expect(elapsed).toBeLessThan(100)
+  })
 })
 
 test('capitalizeAll(), should capitalize the first letter in a word', () => {

--- a/lib/helpers/functions.ts
+++ b/lib/helpers/functions.ts
@@ -109,10 +109,15 @@ export const isUndefined = <T = unknown>(undef: T): boolean =>
 
 export const capitalize = (str: string): string => {
   if (isString(str)) {
-    const regex = /[^a-z]*[a-z]/
-    const [first = ''] = regex.exec(str)
+    const idx = str.search(/[a-z]/)
 
-    return first.toUpperCase() + str.substring(first.length)
+    if (idx === -1) {
+      return str.toUpperCase()
+    }
+
+    const first = str.substring(0, idx + 1)
+
+    return first.toUpperCase() + str.substring(idx + 1)
   }
 
   return ''

--- a/lib/helpers/functions.ts
+++ b/lib/helpers/functions.ts
@@ -410,22 +410,24 @@ export function filterRowsByValue<T = UnknownObject>(
   rows: T[],
   colProperties: Headers<T>,
 ): T[] {
+  const lowerValue = value.toLowerCase()
+
   return rows.filter((row) => {
-    const regex = new RegExp(`.*?${escapeStringRegexp(value)}.*?`, 'i')
-    let hasMatch = false
     const rowKeys = Object.keys(row)
 
     for (let i = 0, N = rowKeys.length; i < N; i += 1) {
       const key = rowKeys[i]
-      const val = row[key] as string
-      const colProps = { ...colProperties[key] }
 
-      if (colProps.filterable !== false) {
-        hasMatch = hasMatch || regex.test(val)
+      if (colProperties[key]?.filterable === false) {
+        continue
+      }
+
+      if (String(row[key]).toLowerCase().includes(lowerValue)) {
+        return true
       }
     }
 
-    return hasMatch
+    return false
   })
 }
 

--- a/lib/helpers/table-action.enum.ts
+++ b/lib/helpers/table-action.enum.ts
@@ -4,7 +4,6 @@ enum TableAction {
   FetchError = 'FETCH_ERROR',
   SetSorting = 'SET_SORTING',
   SetActivePage = 'SET_ACTIVE_PAGE',
-  SetColProperties = 'SET_COL_PROPERTIES',
   ToggleColumn = 'TOGGLE_COLUMN',
   ToggleAllColumns = 'TOGGLE_ALL_COLUMNS',
   ResetPageForFilter = 'RESET_PAGE_FOR_FILTER',

--- a/lib/helpers/table-action.enum.ts
+++ b/lib/helpers/table-action.enum.ts
@@ -1,0 +1,13 @@
+enum TableAction {
+  FetchStart = 'FETCH_START',
+  FetchSuccess = 'FETCH_SUCCESS',
+  FetchError = 'FETCH_ERROR',
+  SetSorting = 'SET_SORTING',
+  SetActivePage = 'SET_ACTIVE_PAGE',
+  SetColProperties = 'SET_COL_PROPERTIES',
+  ToggleColumn = 'TOGGLE_COLUMN',
+  ToggleAllColumns = 'TOGGLE_ALL_COLUMNS',
+  ResetPageForFilter = 'RESET_PAGE_FOR_FILTER',
+}
+
+export default TableAction

--- a/lib/helpers/typed-memo.ts
+++ b/lib/helpers/typed-memo.ts
@@ -1,0 +1,3 @@
+import { memo } from 'react'
+
+export const typedMemo: <T>(c: T) => T = memo

--- a/lib/hooks/useAsyncData.ts
+++ b/lib/hooks/useAsyncData.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react'
+import type { Dispatch } from 'react'
+import type { TableReducerAction } from './useTableReducer'
+import type {
+  Column,
+  FetchDataOptions,
+  Headers,
+  UnknownObject,
+} from '../helpers/functions'
+import TableAction from '../helpers/table-action.enum'
+import * as utils from '../helpers/functions'
+
+interface UseAsyncDataOptions<T> {
+  data: string | T[]
+  dataKey: string
+  dataKeyResolver: utils.KeyResolverFN<T>
+  dataRequestOptions: RequestInit
+  headers: Headers<T>
+  orderedHeaders: string[]
+  hideUnordered: boolean
+  dataSampling: number
+  dispatch: Dispatch<TableReducerAction<T>>
+}
+
+export function useAsyncData<T = UnknownObject>({
+  data,
+  dataKey,
+  dataKeyResolver,
+  dataRequestOptions,
+  headers,
+  orderedHeaders,
+  hideUnordered,
+  dataSampling,
+  dispatch,
+}: UseAsyncDataOptions<T>): void {
+  const prevDataRef = useRef<string | T[]>(data)
+
+  useEffect(() => {
+    const prevData = prevDataRef.current
+    prevDataRef.current = data
+
+    if (!utils.isString(data)) {
+      return
+    }
+
+    // Only fetch if data is a string (URL) and has changed or is first mount
+    if (
+      typeof data !== typeof prevData ||
+      data !== prevData ||
+      prevData === data
+    ) {
+      const fetchOptions: FetchDataOptions<T> = {
+        dataKey,
+        dataKeyResolver,
+        options: dataRequestOptions,
+      }
+
+      dispatch({ type: TableAction.FetchStart })
+
+      void utils
+        .fetchData(data as string, fetchOptions)
+        .then((asyncData) => {
+          const columns = utils.parseDataForColumns<T>(
+            asyncData as T[],
+            headers,
+            orderedHeaders,
+            hideUnordered,
+            dataSampling,
+          )
+
+          dispatch({
+            type: TableAction.FetchSuccess,
+            asyncData: asyncData as T[],
+            columns: columns as Column<T>[],
+          })
+        })
+        .catch((err) => {
+          dispatch({ type: TableAction.FetchError })
+          throw new Error(String(err), { cause: err })
+        })
+    }
+  }, [
+    data,
+    dataKey,
+    dataKeyResolver,
+    dataRequestOptions,
+    headers,
+    orderedHeaders,
+    hideUnordered,
+    dataSampling,
+    dispatch,
+  ])
+}

--- a/lib/hooks/useAsyncData.ts
+++ b/lib/hooks/useAsyncData.ts
@@ -1,11 +1,7 @@
 import { useEffect, useRef } from 'react'
 import type { Dispatch } from 'react'
 import type { TableReducerAction } from './useTableReducer'
-import type {
-  Column,
-  FetchDataOptions,
-  UnknownObject,
-} from '../helpers/functions'
+import type { Column, UnknownObject } from '../helpers/functions'
 import TableAction from '../helpers/table-action.enum'
 import * as utils from '../helpers/functions'
 
@@ -52,17 +48,16 @@ export function useAsyncData<T = UnknownObject>({
       return
     }
 
-    const fetchOptions: FetchDataOptions<T> = {
-      dataKey,
-      dataKeyResolver,
-      options: dataRequestOptions,
-    }
+    const doFetch = async () => {
+      dispatch({ type: TableAction.FetchStart })
 
-    dispatch({ type: TableAction.FetchStart })
+      try {
+        const asyncData = await utils.fetchData(data as string, {
+          dataKey,
+          dataKeyResolver,
+          options: dataRequestOptions,
+        })
 
-    void utils
-      .fetchData(data as string, fetchOptions)
-      .then((asyncData) => {
         const currentDeps = columnDepsRef.current
 
         const columns = utils.parseDataForColumns<T>(
@@ -78,10 +73,12 @@ export function useAsyncData<T = UnknownObject>({
           asyncData: asyncData as T[],
           columns: columns as Column<T>[],
         })
-      })
-      .catch((err: unknown) => {
+      } catch (err: unknown) {
         dispatch({ type: TableAction.FetchError })
         utils.errorPrint(err)
-      })
+      }
+    }
+
+    void doFetch()
   }, [data, dataKey, dataKeyResolver, dataRequestOptions, dispatch])
 }

--- a/lib/hooks/useAsyncData.ts
+++ b/lib/hooks/useAsyncData.ts
@@ -84,9 +84,9 @@ export function useAsyncData<T = UnknownObject>({
           columns: columns as Column<T>[],
         })
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         dispatch({ type: TableAction.FetchError })
-        throw new Error(String(err), { cause: err })
+        utils.errorPrint(err)
       })
   }, [data, dataKey, dataKeyResolver, dataRequestOptions, dispatch])
 }

--- a/lib/hooks/useAsyncData.ts
+++ b/lib/hooks/useAsyncData.ts
@@ -4,7 +4,6 @@ import type { TableReducerAction } from './useTableReducer'
 import type {
   Column,
   FetchDataOptions,
-  Headers,
   UnknownObject,
 } from '../helpers/functions'
 import TableAction from '../helpers/table-action.enum'
@@ -15,7 +14,7 @@ interface UseAsyncDataOptions<T> {
   dataKey: string
   dataKeyResolver: utils.KeyResolverFN<T>
   dataRequestOptions: RequestInit
-  headers: Headers<T>
+  headers: utils.Headers<T>
   orderedHeaders: string[]
   hideUnordered: boolean
   dataSampling: number
@@ -33,61 +32,61 @@ export function useAsyncData<T = UnknownObject>({
   dataSampling,
   dispatch,
 }: UseAsyncDataOptions<T>): void {
-  const prevDataRef = useRef<string | T[]>(data)
-
-  useEffect(() => {
-    const prevData = prevDataRef.current
-    prevDataRef.current = data
-
-    if (!utils.isString(data)) {
-      return
-    }
-
-    // Only fetch if data is a string (URL) and has changed or is first mount
-    if (
-      typeof data !== typeof prevData ||
-      data !== prevData ||
-      prevData === data
-    ) {
-      const fetchOptions: FetchDataOptions<T> = {
-        dataKey,
-        dataKeyResolver,
-        options: dataRequestOptions,
-      }
-
-      dispatch({ type: TableAction.FetchStart })
-
-      void utils
-        .fetchData(data as string, fetchOptions)
-        .then((asyncData) => {
-          const columns = utils.parseDataForColumns<T>(
-            asyncData as T[],
-            headers,
-            orderedHeaders,
-            hideUnordered,
-            dataSampling,
-          )
-
-          dispatch({
-            type: TableAction.FetchSuccess,
-            asyncData: asyncData as T[],
-            columns: columns as Column<T>[],
-          })
-        })
-        .catch((err) => {
-          dispatch({ type: TableAction.FetchError })
-          throw new Error(String(err), { cause: err })
-        })
-    }
-  }, [
-    data,
-    dataKey,
-    dataKeyResolver,
-    dataRequestOptions,
+  // Capture column-parsing deps in a ref so they don't trigger re-fetches.
+  // Only `data` changes should trigger a new fetch (matching original behavior).
+  const columnDepsRef = useRef({
     headers,
     orderedHeaders,
     hideUnordered,
     dataSampling,
-    dispatch,
-  ])
+  })
+  columnDepsRef.current = {
+    headers,
+    orderedHeaders,
+    hideUnordered,
+    dataSampling,
+  }
+
+  useEffect(() => {
+    if (!utils.isString(data)) {
+      return
+    }
+
+    const fetchOptions: FetchDataOptions<T> = {
+      dataKey,
+      dataKeyResolver,
+      options: dataRequestOptions,
+    }
+
+    dispatch({ type: TableAction.FetchStart })
+
+    void utils
+      .fetchData(data as string, fetchOptions)
+      .then((asyncData) => {
+        const {
+          headers: h,
+          orderedHeaders: oh,
+          hideUnordered: hu,
+          dataSampling: ds,
+        } = columnDepsRef.current
+
+        const columns = utils.parseDataForColumns<T>(
+          asyncData as T[],
+          h,
+          oh,
+          hu,
+          ds,
+        )
+
+        dispatch({
+          type: TableAction.FetchSuccess,
+          asyncData: asyncData as T[],
+          columns: columns as Column<T>[],
+        })
+      })
+      .catch((err) => {
+        dispatch({ type: TableAction.FetchError })
+        throw new Error(String(err), { cause: err })
+      })
+  }, [data, dataKey, dataKeyResolver, dataRequestOptions, dispatch])
 }

--- a/lib/hooks/useAsyncData.ts
+++ b/lib/hooks/useAsyncData.ts
@@ -63,19 +63,14 @@ export function useAsyncData<T = UnknownObject>({
     void utils
       .fetchData(data as string, fetchOptions)
       .then((asyncData) => {
-        const {
-          headers: h,
-          orderedHeaders: oh,
-          hideUnordered: hu,
-          dataSampling: ds,
-        } = columnDepsRef.current
+        const currentDeps = columnDepsRef.current
 
         const columns = utils.parseDataForColumns<T>(
           asyncData as T[],
-          h,
-          oh,
-          hu,
-          ds,
+          currentDeps.headers,
+          currentDeps.orderedHeaders,
+          currentDeps.hideUnordered,
+          currentDeps.dataSampling,
         )
 
         dispatch({

--- a/lib/hooks/useColumns.ts
+++ b/lib/hooks/useColumns.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react'
+import type { Column, Headers, UnknownObject } from '../helpers/functions'
+import * as utils from '../helpers/functions'
+
+interface UseColumnsOptions<T> {
+  resolvedData: T[]
+  stateColumns: Column<T>[]
+  headers: Headers<T>
+  orderedHeaders: string[]
+  hideUnordered: boolean
+  dataSampling: number
+  dynamic: boolean
+}
+
+export function useColumns<T = UnknownObject>({
+  resolvedData,
+  stateColumns,
+  headers,
+  orderedHeaders,
+  hideUnordered,
+  dataSampling,
+  dynamic,
+}: UseColumnsOptions<T>): Column<T>[] {
+  return useMemo(() => {
+    if (!dynamic && !utils.isEmpty(stateColumns)) {
+      return stateColumns
+    }
+
+    return utils.parseDataForColumns<T>(
+      resolvedData,
+      headers,
+      orderedHeaders,
+      hideUnordered,
+      dataSampling,
+    )
+  }, [
+    resolvedData,
+    stateColumns,
+    headers,
+    orderedHeaders,
+    hideUnordered,
+    dataSampling,
+    dynamic,
+  ])
+}

--- a/lib/hooks/useRows.ts
+++ b/lib/hooks/useRows.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react'
+import type { Headers, Sorting, UnknownObject } from '../helpers/functions'
+import * as utils from '../helpers/functions'
+import { ORDER_ASC } from '../helpers/constants'
+
+interface UseRowsOptions<T> {
+  resolvedData: T[]
+  sorting: Sorting
+  colProperties: Headers<T>
+  filterValue: string
+  activePage: number
+  perPage: number
+}
+
+interface UseRowsResult<T> {
+  flattenedRows: T[]
+  filteredRows: T[]
+  visibleRows: T[]
+}
+
+export function useRows<T = UnknownObject>({
+  resolvedData,
+  sorting,
+  colProperties,
+  filterValue,
+  activePage,
+  perPage,
+}: UseRowsOptions<T>): UseRowsResult<T> {
+  // Layer 2: Flatten once
+  const flattenedRows = useMemo(
+    () => utils.parseDataForRows(resolvedData),
+    [resolvedData],
+  )
+
+  // Layer 3: Sort only when sorting changes
+  const sortedRows = useMemo(() => {
+    const { dir, key } = sorting
+
+    if (!dir) {
+      return flattenedRows
+    }
+
+    const compareFn =
+      typeof colProperties[key]?.sortable === 'function' &&
+      colProperties[key].sortable
+
+    const sorted = utils.sortBy(flattenedRows, key, compareFn)
+
+    return dir === ORDER_ASC ? sorted : sorted.reverse()
+  }, [flattenedRows, sorting, colProperties])
+
+  // Layer 4: Filter only when filter changes
+  const filteredRows = useMemo(
+    () => utils.filterRows(filterValue, sortedRows, colProperties),
+    [filterValue, sortedRows, colProperties],
+  )
+
+  // Layer 5: Slice for pagination
+  const visibleRows = useMemo(
+    () => utils.sliceRowsPerPage(filteredRows, activePage, perPage),
+    [filteredRows, activePage, perPage],
+  )
+
+  return { flattenedRows, filteredRows, visibleRows }
+}

--- a/lib/hooks/useRows.ts
+++ b/lib/hooks/useRows.ts
@@ -13,7 +13,6 @@ interface UseRowsOptions<T> {
 }
 
 interface UseRowsResult<T> {
-  flattenedRows: T[]
   filteredRows: T[]
   visibleRows: T[]
 }
@@ -61,5 +60,5 @@ export function useRows<T = UnknownObject>({
     [filteredRows, activePage, perPage],
   )
 
-  return { flattenedRows, filteredRows, visibleRows }
+  return { filteredRows, visibleRows }
 }

--- a/lib/hooks/useTableReducer.test.ts
+++ b/lib/hooks/useTableReducer.test.ts
@@ -1,0 +1,275 @@
+import { renderHook, act } from '@testing-library/react'
+import { useTableReducer } from './useTableReducer'
+import type { TableReducerAction } from './useTableReducer'
+import TableAction from '../helpers/table-action.enum'
+import { ORDER_ASC, ORDER_DESC } from '../helpers/constants'
+import type { Column, Headers, UnknownObject } from '../helpers/functions'
+
+function setup(initialColProperties?: Headers<UnknownObject>) {
+  return renderHook(() => useTableReducer(initialColProperties))
+}
+
+function dispatch(
+  hook: ReturnType<typeof setup>,
+  action: TableReducerAction<UnknownObject>,
+) {
+  act(() => {
+    hook.result.current[1](action)
+  })
+}
+
+const mockColumn: Column<UnknownObject> = {
+  key: 'name',
+  text: 'Name',
+  invisible: false,
+  sortable: true,
+  filterable: true,
+  isImg: false,
+}
+
+describe('useTableReducer', () => {
+  it('initializes with default state', () => {
+    const { result } = setup()
+    const [state] = result.current
+
+    expect(state.activePage).toBe(1)
+    expect(state.asyncData).toEqual([])
+    expect(state.colProperties).toEqual({})
+    expect(state.columns).toEqual([])
+    expect(state.isLoading).toBe(false)
+    expect(state.sorting).toEqual({ key: '', dir: '' })
+  })
+
+  it('initializes with provided colProperties', () => {
+    const headers = { name: mockColumn } as Headers<UnknownObject>
+    const { result } = setup(headers)
+
+    expect(result.current[0].colProperties).toBe(headers)
+  })
+
+  describe('FetchStart / FetchSuccess / FetchError', () => {
+    it('sets isLoading on FetchStart', () => {
+      const hook = setup()
+
+      dispatch(hook, { type: TableAction.FetchStart })
+
+      expect(hook.result.current[0].isLoading).toBe(true)
+    })
+
+    it('sets asyncData, columns, and clears isLoading on FetchSuccess', () => {
+      const hook = setup()
+      const asyncData = [{ name: 'Alice' }]
+      const columns = [mockColumn]
+
+      dispatch(hook, { type: TableAction.FetchStart })
+      dispatch(hook, {
+        type: TableAction.FetchSuccess,
+        asyncData,
+        columns,
+      })
+
+      const state = hook.result.current[0]
+
+      expect(state.isLoading).toBe(false)
+      expect(state.asyncData).toBe(asyncData)
+      expect(state.columns).toBe(columns)
+    })
+
+    it('clears isLoading on FetchError', () => {
+      const hook = setup()
+
+      dispatch(hook, { type: TableAction.FetchStart })
+      dispatch(hook, { type: TableAction.FetchError })
+
+      expect(hook.result.current[0].isLoading).toBe(false)
+    })
+  })
+
+  describe('SetSorting', () => {
+    it('cycles: none → ASC → DESC → none', () => {
+      const hook = setup()
+
+      // First click: none → ASC
+      dispatch(hook, { type: TableAction.SetSorting, column: mockColumn })
+
+      expect(hook.result.current[0].sorting).toEqual({
+        key: 'name',
+        dir: ORDER_ASC,
+      })
+
+      // Second click: ASC → DESC
+      dispatch(hook, { type: TableAction.SetSorting, column: mockColumn })
+
+      expect(hook.result.current[0].sorting).toEqual({
+        key: 'name',
+        dir: ORDER_DESC,
+      })
+
+      // Third click: DESC → none
+      dispatch(hook, { type: TableAction.SetSorting, column: mockColumn })
+
+      expect(hook.result.current[0].sorting).toEqual({
+        key: 'name',
+        dir: '',
+      })
+    })
+
+    it('resets to ASC when switching columns', () => {
+      const hook = setup()
+      const otherColumn = { ...mockColumn, key: 'email', text: 'Email' }
+
+      // Sort by name ASC
+      dispatch(hook, { type: TableAction.SetSorting, column: mockColumn })
+
+      expect(hook.result.current[0].sorting.dir).toBe(ORDER_ASC)
+
+      // Switch to email — should start at ASC, not continue cycle
+      dispatch(hook, { type: TableAction.SetSorting, column: otherColumn })
+
+      expect(hook.result.current[0].sorting).toEqual({
+        key: 'email',
+        dir: ORDER_ASC,
+      })
+    })
+
+    it('produces a new sorting object (immutable)', () => {
+      const hook = setup()
+      const sortingBefore = hook.result.current[0].sorting
+
+      dispatch(hook, { type: TableAction.SetSorting, column: mockColumn })
+
+      const sortingAfter = hook.result.current[0].sorting
+
+      expect(sortingAfter).not.toBe(sortingBefore)
+    })
+  })
+
+  describe('SetActivePage', () => {
+    it('sets the active page', () => {
+      const hook = setup()
+
+      dispatch(hook, { type: TableAction.SetActivePage, activePage: 5 })
+
+      expect(hook.result.current[0].activePage).toBe(5)
+    })
+  })
+
+  describe('ToggleColumn', () => {
+    it('toggles an existing column invisible', () => {
+      const headers = {
+        name: { ...mockColumn, invisible: false },
+      } as Headers<UnknownObject>
+      const hook = setup(headers)
+
+      dispatch(hook, { type: TableAction.ToggleColumn, key: 'name' })
+
+      expect(hook.result.current[0].colProperties.name.invisible).toBe(true)
+    })
+
+    it('toggles back to visible', () => {
+      const headers = {
+        name: { ...mockColumn, invisible: false },
+      } as Headers<UnknownObject>
+      const hook = setup(headers)
+
+      dispatch(hook, { type: TableAction.ToggleColumn, key: 'name' })
+      dispatch(hook, { type: TableAction.ToggleColumn, key: 'name' })
+
+      expect(hook.result.current[0].colProperties.name.invisible).toBe(false)
+    })
+
+    it('creates colProperties entry for unknown key', () => {
+      const hook = setup()
+
+      dispatch(hook, { type: TableAction.ToggleColumn, key: 'unknown' })
+
+      expect(hook.result.current[0].colProperties.unknown).toBeDefined()
+      expect(hook.result.current[0].colProperties.unknown.invisible).toBe(true)
+    })
+
+    it('does not mutate previous state', () => {
+      const headers = {
+        name: { ...mockColumn },
+      } as Headers<UnknownObject>
+      const hook = setup(headers)
+      const colPropsBefore = hook.result.current[0].colProperties
+
+      dispatch(hook, { type: TableAction.ToggleColumn, key: 'name' })
+
+      const colPropsAfter = hook.result.current[0].colProperties
+
+      expect(colPropsAfter).not.toBe(colPropsBefore)
+      expect(colPropsAfter.name).not.toBe(colPropsBefore.name)
+    })
+  })
+
+  describe('ToggleAllColumns', () => {
+    it('sets all columns invisible when isChecked is true', () => {
+      const columns = [
+        mockColumn,
+        { ...mockColumn, key: 'email', text: 'Email' },
+      ]
+      const hook = setup()
+
+      dispatch(hook, {
+        type: TableAction.ToggleAllColumns,
+        columns,
+        isChecked: true,
+      })
+
+      const { colProperties } = hook.result.current[0]
+
+      expect(colProperties.name.invisible).toBe(true)
+      expect(colProperties.email.invisible).toBe(true)
+    })
+
+    it('sets all columns visible when isChecked is false', () => {
+      const columns = [mockColumn]
+      const hook = setup()
+
+      dispatch(hook, {
+        type: TableAction.ToggleAllColumns,
+        columns,
+        isChecked: true,
+      })
+      dispatch(hook, {
+        type: TableAction.ToggleAllColumns,
+        columns,
+        isChecked: false,
+      })
+
+      expect(hook.result.current[0].colProperties.name.invisible).toBe(false)
+    })
+  })
+
+  describe('ResetPageForFilter', () => {
+    it('resets activePage to 1 and updates prevFilterValue', () => {
+      const hook = setup()
+
+      dispatch(hook, { type: TableAction.SetActivePage, activePage: 5 })
+
+      expect(hook.result.current[0].activePage).toBe(5)
+
+      dispatch(hook, {
+        type: TableAction.ResetPageForFilter,
+        filterValue: 'search',
+      })
+
+      expect(hook.result.current[0].activePage).toBe(1)
+      expect(hook.result.current[0].prevFilterValue).toBe('search')
+    })
+  })
+
+  it('returns state unchanged for unknown action', () => {
+    const hook = setup()
+    const stateBefore = hook.result.current[0]
+
+    act(() => {
+      hook.result.current[1]({
+        type: 'UNKNOWN',
+      } as unknown as TableReducerAction)
+    })
+
+    expect(hook.result.current[0]).toBe(stateBefore)
+  })
+})

--- a/lib/hooks/useTableReducer.ts
+++ b/lib/hooks/useTableReducer.ts
@@ -11,7 +11,6 @@ export type TableReducerAction<T = UnknownObject> =
   | { type: TableAction.FetchError }
   | { type: TableAction.SetSorting; column: Column<T> }
   | { type: TableAction.SetActivePage; activePage: number }
-  | { type: TableAction.SetColProperties; colProperties: Headers<T> }
   | { type: TableAction.ToggleColumn; key: string }
   | {
       type: TableAction.ToggleAllColumns
@@ -55,9 +54,6 @@ function tableReducer<T = UnknownObject>(
 
     case TableAction.SetActivePage:
       return { ...state, activePage: action.activePage }
-
-    case TableAction.SetColProperties:
-      return { ...state, colProperties: action.colProperties }
 
     case TableAction.ToggleColumn: {
       const { key } = action

--- a/lib/hooks/useTableReducer.ts
+++ b/lib/hooks/useTableReducer.ts
@@ -1,0 +1,111 @@
+import { useReducer } from 'react'
+import type { SmartDataTableState } from '../types'
+import type { Column, Headers, UnknownObject } from '../helpers/functions'
+import TableAction from '../helpers/table-action.enum'
+import * as constants from '../helpers/constants'
+import defaultState from '../helpers/default-state'
+
+export type TableReducerAction<T = UnknownObject> =
+  | { type: TableAction.FetchStart }
+  | { type: TableAction.FetchSuccess; asyncData: T[]; columns: Column<T>[] }
+  | { type: TableAction.FetchError }
+  | { type: TableAction.SetSorting; column: Column<T> }
+  | { type: TableAction.SetActivePage; activePage: number }
+  | { type: TableAction.SetColProperties; colProperties: Headers<T> }
+  | { type: TableAction.ToggleColumn; key: string }
+  | {
+      type: TableAction.ToggleAllColumns
+      columns: Column<T>[]
+      isChecked: boolean
+    }
+  | { type: TableAction.ResetPageForFilter; filterValue: string }
+
+function tableReducer<T = UnknownObject>(
+  state: SmartDataTableState<T>,
+  action: TableReducerAction<T>,
+): SmartDataTableState<T> {
+  switch (action.type) {
+    case TableAction.FetchStart:
+      return { ...state, isLoading: true }
+
+    case TableAction.FetchSuccess:
+      return {
+        ...state,
+        asyncData: action.asyncData,
+        columns: action.columns,
+        isLoading: false,
+      }
+
+    case TableAction.FetchError:
+      return { ...state, isLoading: false }
+
+    case TableAction.SetSorting: {
+      const { key } = action.column
+      const prevDir = state.sorting.key === key ? state.sorting.dir : ''
+      let dir: string
+
+      if (prevDir) {
+        dir = prevDir === constants.ORDER_ASC ? constants.ORDER_DESC : ''
+      } else {
+        dir = constants.ORDER_ASC
+      }
+
+      return { ...state, sorting: { key, dir } }
+    }
+
+    case TableAction.SetActivePage:
+      return { ...state, activePage: action.activePage }
+
+    case TableAction.SetColProperties:
+      return { ...state, colProperties: action.colProperties }
+
+    case TableAction.ToggleColumn: {
+      const { key } = action
+      const prev = state.colProperties[key] ?? {
+        ...constants.defaultHeader,
+        key,
+      }
+
+      return {
+        ...state,
+        colProperties: {
+          ...state.colProperties,
+          [key]: { ...prev, invisible: !prev.invisible },
+        },
+      }
+    }
+
+    case TableAction.ToggleAllColumns: {
+      const newColProperties = { ...state.colProperties }
+
+      for (const { key } of action.columns) {
+        const prev = newColProperties[key] ?? {
+          ...constants.defaultHeader,
+          key,
+        }
+        newColProperties[key] = { ...prev, invisible: action.isChecked }
+      }
+
+      return { ...state, colProperties: newColProperties }
+    }
+
+    case TableAction.ResetPageForFilter:
+      return {
+        ...state,
+        activePage: 1,
+        prevFilterValue: action.filterValue,
+      }
+
+    default:
+      return state
+  }
+}
+
+export function useTableReducer<T = UnknownObject>(
+  initialColProperties: Headers<T> = {} as Headers<T>,
+) {
+  return useReducer(tableReducer<T>, {
+    ...(defaultState as SmartDataTableState<T>),
+    colProperties: initialColProperties,
+  })
+}


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Chore
- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Tests
- [ ] Documentation

### Summary

Convert `SmartDataTable` from a class component to a function component with hooks, introducing layered memoization so that each stage of the data pipeline (flatten, sort, filter, paginate) only recomputes when its specific inputs change. Also fixes bugs and a security vulnerability.

### Change description

#### Performance: memoized data pipeline

The class component recomputed the entire data pipeline (flatten → sort → filter → slice) on every render — even when only the active page changed. The new function component uses a layered `useMemo` chain where each stage depends only on its inputs:

| User action | Flatten | Sort | Filter | Slice |
|-------------|---------|------|--------|-------|
| Page change | skip | skip | skip | O(1) |
| Sort change | skip | O(n log n) | O(n·m) | O(1) |
| Filter change | skip | skip | O(n·m) | O(1) |
| Data change | O(n) | O(n log n) | O(n·m) | O(1) |

Verified with perf tests: `parseDataForRows` is called **0 extra times** on page/sort/filter changes (was 1 each before).

#### Architecture: class → function component with hooks

- **`useTableReducer`** — centralizes 7 interdependent state fields into a single `useReducer` with a `TableAction` enum, making state transitions immutable by design
- **`useAsyncData`** — extracts fetch lifecycle; column-parsing deps are captured in a ref so only `data` URL changes trigger re-fetches
- **`useColumns`** / **`useRows`** — memoized data pipeline hooks
- **`DataRow`** — extracted `React.memo` component with `typedMemo` helper to preserve generics
- **Table sub-components** — all wrapped with `memo`
- **Stable callbacks** — all handlers use `useCallback` with `dispatch` (referentially stable from `useReducer`)
- **Stable prop defaults** — object/array/function defaults hoisted to module-level constants to prevent memoization invalidation

#### Bug fixes

- **State mutation in `handleSortChange`** — `sorting.dir = ''` mutated state directly; now immutable via reducer
- **Stale `totalPages` in `withPagination` HOC** — only computed in constructor, never updated; replaced with inline `useMemo`
- **HOC recreated on every render** — `withPagination(PaginatorComponent)` called inside `renderPagination` created a new component type each render; eliminated entirely

#### Security fix

- **ReDoS in `capitalize()`** ([code-scanning #2](https://github.com/joaocarmo/react-smart-data-table/security/code-scanning/2)) — `/[^a-z]*[a-z]/` caused polynomial backtracking on strings with repeated non-lowercase characters; replaced with `str.search(/[a-z]/)` (linear, no backtracking)
- **ReDoS in `filterRowsByValue()`** — per-row `new RegExp(...)` replaced with `String.includes()` (faster, no regex compilation)

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [x] Tests passed (177 tests across 6 suites)
- [x] Coding style respected